### PR TITLE
fix: Replace info with optional sender in simulate_swap

### DIFF
--- a/src/implementations/osmosis/osmosis.rs
+++ b/src/implementations/osmosis/osmosis.rs
@@ -18,8 +18,8 @@ use apollo_proto_rust::utils::encode;
 use apollo_proto_rust::OsmosisTypeURLs;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    Addr, Coin, CosmosMsg, Decimal, Deps, Event, Fraction, MessageInfo, QuerierWrapper,
-    QueryRequest, Response, StdError, StdResult, Uint128,
+    Addr, Coin, CosmosMsg, Decimal, Deps, Event, Fraction, QuerierWrapper, QueryRequest, Response,
+    StdError, StdResult, Uint128,
 };
 use cw_asset::{Asset, AssetInfo, AssetList};
 use osmo_bindings::{OsmosisQuery, PoolStateResponse};
@@ -248,17 +248,18 @@ impl Pool for OsmosisPool {
     fn simulate_swap(
         &self,
         deps: Deps,
-        info: MessageInfo,
         offer: Asset,
         _ask_asset_info: AssetInfo,
         _minimum_out_amount: Uint128,
+        sender: Option<String>,
     ) -> StdResult<Uint128> {
         let offer: Coin = offer.try_into()?;
         let swap_response =
             deps.querier.query::<QuerySwapExactAmountInResponse>(&QueryRequest::Stargate {
                 path: OsmosisTypeURLs::QuerySwapExactAmountIn.to_string(),
                 data: encode(QuerySwapExactAmountInRequest {
-                    sender: info.sender.to_string(),
+                    sender: sender
+                        .ok_or(StdError::generic_err("sender is required for osmosis"))?,
                     pool_id: self.pool_id,
                     routes: vec![SwapAmountInRoute {
                         pool_id: self.pool_id,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Decimal, MessageInfo, Response, StdResult};
+use cosmwasm_std::{Addr, Decimal, Response, StdResult};
 use cosmwasm_std::{Deps, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetList};
 
@@ -77,9 +77,12 @@ pub trait Pool {
     fn simulate_swap(
         &self,
         deps: Deps,
-        info: MessageInfo,
         offer_asset: Asset,
         ask_asset_info: AssetInfo,
         minimum_out_amount: Uint128,
+        //For some reason Osmosis requires us to send a sender address for simulation.
+        //This obviously makes no sense and I guess we'll have to make a PR to
+        //Osmosis to fix this, or perhaps copy their math and perform the calculation here...
+        sender: Option<String>,
     ) -> StdResult<Uint128>;
 }


### PR DESCRIPTION
Osmosis requires us to pass sender as an argument to their swap query, which makes no sense, but for now we just add an optional sender field instead of taking in `MessageInfo` because contract queries do not have access to `MessageInfo`.