### PR TITLE
Add Pool enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum CwDexError {
 
     #[error("Overflow when converting to from BigInt to Uint128")]
     BigIntOverflow {},
+
+    #[error("Asset is not an LP token")]
+    NotLpToken {},
 }
 
 impl From<CwDexError> for StdError {

--- a/src/implementations/mod.rs
+++ b/src/implementations/mod.rs
@@ -1,1 +1,4 @@
 pub mod osmosis;
+pub mod pool;
+
+pub use pool::*;

--- a/src/implementations/osmosis/helpers.rs
+++ b/src/implementations/osmosis/helpers.rs
@@ -1,22 +1,16 @@
 use std::{convert::TryInto, time::Duration};
 
 use apollo_proto_rust::{
-    osmosis::{
-        gamm::v1beta1::{PoolParams, QueryPoolParamsRequest, QueryPoolParamsResponse},
-        lockup::{
-            AccountLockedLongerDurationNotUnlockingOnlyRequest,
-            AccountLockedLongerDurationNotUnlockingOnlyResponse, PeriodLock,
-        },
-    },
+    osmosis::gamm::v1beta1::{PoolParams, QueryPoolParamsRequest, QueryPoolParamsResponse},
     utils::encode,
     OsmosisTypeURLs,
 };
 use cosmwasm_std::{
-    from_binary, Addr, Coin, CustomQuery, QuerierWrapper, QueryRequest, StdError, StdResult,
+    from_binary, Coin, CustomQuery, QuerierWrapper, QueryRequest, StdError, StdResult,
 };
 use cw_asset::{Asset, AssetInfo, AssetList};
 
-use crate::CwDexError;
+use crate::error::CwDexError;
 
 pub(crate) fn query_pool_params<C: CustomQuery>(
     querier: QuerierWrapper<C>,

--- a/src/implementations/osmosis/osmosis.rs
+++ b/src/implementations/osmosis/osmosis.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use apollo_proto_rust::osmosis::gamm::v1beta1::{
-    MsgExitPool, MsgJoinPool, MsgJoinSwapExternAmountIn, MsgSwapExactAmountIn,
-    QuerySwapExactAmountInRequest, QuerySwapExactAmountInResponse, QueryTotalPoolLiquidityRequest,
+    MsgExitPool, MsgJoinSwapExternAmountIn, MsgSwapExactAmountIn, QuerySwapExactAmountInRequest,
+    QuerySwapExactAmountInResponse, QueryTotalPoolLiquidityRequest,
     QueryTotalPoolLiquidityResponse, SwapAmountInRoute,
 };
 
@@ -18,17 +18,18 @@ use apollo_proto_rust::utils::encode;
 use apollo_proto_rust::OsmosisTypeURLs;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    Addr, Coin, CosmosMsg, Decimal, Deps, Event, Fraction, QuerierWrapper, QueryRequest, ReplyOn,
-    Response, StdError, StdResult, SubMsg, Uint128,
+    Addr, Coin, CosmosMsg, Decimal, Deps, Event, QuerierWrapper, QueryRequest, ReplyOn, Response,
+    StdError, StdResult, SubMsg, Uint128,
 };
 use cw_asset::{Asset, AssetInfo, AssetList};
-use osmo_bindings::{OsmosisQuery, PoolStateResponse};
+use osmo_bindings::OsmosisQuery;
 
 use crate::osmosis::osmosis_math::{
     osmosis_calculate_exit_pool_amounts, osmosis_calculate_join_pool_shares,
 };
+use crate::traits::{Lockup, Pool, Staking};
 use crate::utils::vec_into;
-use crate::{CwDexError, Lockup, Pool, Staking};
+use crate::CwDexError;
 
 use super::helpers::{
     assert_native_asset_info, assert_native_coin, assert_only_native_coins, merge_assets,

--- a/src/implementations/pool.rs
+++ b/src/implementations/pool.rs
@@ -1,0 +1,113 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Deps;
+use cw_asset::AssetInfo;
+use std::str::FromStr;
+
+use crate::error::CwDexError;
+use crate::implementations::osmosis::OsmosisPool;
+use crate::traits::pool::Pool as PoolTrait;
+
+/// An enum with all known variants that implement the Pool trait.
+/// The ideal solution would of course instead be to use a trait object so that
+/// the caller can pass in any type that implements the Pool trait, but trait
+/// objects require us not to implement the Sized trait, which cw_serde requires.
+#[cw_serde]
+#[derive(Copy)]
+pub enum Pool {
+    Osmosis(OsmosisPool),
+}
+
+impl Pool {
+    pub fn as_trait(&self) -> Box<dyn PoolTrait> {
+        match self {
+            Pool::Osmosis(x) => Box::new(x.clone()),
+        }
+    }
+
+    pub fn get_pool_for_lp_token(_deps: Deps, lp_token: &AssetInfo) -> Result<Self, CwDexError> {
+        match lp_token {
+            cw_asset::AssetInfoBase::Native(lp_token_denom) => {
+                //The only Pool implementation that uses native denoms right now is Osmosis
+                if !lp_token_denom.starts_with("gamm/pool/") {
+                    return Err(CwDexError::NotLpToken {});
+                }
+
+                let pool_id_str =
+                    lp_token_denom.strip_prefix("gamm/pool/").ok_or(CwDexError::NotLpToken {})?;
+
+                let pool_id = u64::from_str(pool_id_str).map_err(|_| CwDexError::NotLpToken {})?;
+
+                Ok(Pool::Osmosis(OsmosisPool {
+                    pool_id,
+                }))
+            }
+            _ => Err(CwDexError::NotLpToken {}), //TODO: Support Astroport, Junoswap, etc.
+        }
+    }
+}
+
+/// Implement the Pool trait for the Pool enum so we can use all the trait mehtods
+/// directly on the enum type.
+/// TODO: Use "enum_dispatch" macro instead? https://crates.io/crates/enum_dispatch
+impl PoolTrait for Pool {
+    fn provide_liquidity(
+        &self,
+        deps: Deps,
+        assets: cw_asset::AssetList,
+        recipient: cosmwasm_std::Addr,
+        slippage_tolerance: Option<cosmwasm_std::Decimal>,
+    ) -> Result<cosmwasm_std::Response, CwDexError> {
+        self.as_trait().provide_liquidity(deps, assets, recipient, slippage_tolerance)
+    }
+
+    fn withdraw_liquidity(
+        &self,
+        deps: Deps,
+        asset: cw_asset::Asset,
+        recipient: cosmwasm_std::Addr,
+    ) -> Result<cosmwasm_std::Response, CwDexError> {
+        self.as_trait().withdraw_liquidity(deps, asset, recipient)
+    }
+
+    fn swap(
+        &self,
+        deps: Deps,
+        offer_asset: cw_asset::Asset,
+        ask_asset_info: AssetInfo,
+        minimum_out_amount: cosmwasm_std::Uint128,
+        recipient: cosmwasm_std::Addr,
+    ) -> Result<cosmwasm_std::Response, CwDexError> {
+        self.as_trait().swap(deps, offer_asset, ask_asset_info, minimum_out_amount, recipient)
+    }
+
+    fn get_pool_liquidity(&self, deps: Deps) -> Result<cw_asset::AssetList, CwDexError> {
+        self.as_trait().get_pool_liquidity(deps)
+    }
+
+    fn simulate_provide_liquidity(
+        &self,
+        deps: Deps,
+        asset: cw_asset::AssetList,
+    ) -> Result<cw_asset::Asset, CwDexError> {
+        self.as_trait().simulate_provide_liquidity(deps, asset)
+    }
+
+    fn simulate_withdraw_liquidity(
+        &self,
+        deps: Deps,
+        asset: cw_asset::Asset,
+    ) -> Result<cw_asset::AssetList, CwDexError> {
+        self.as_trait().simulate_withdraw_liquidity(deps, asset)
+    }
+
+    fn simulate_swap(
+        &self,
+        deps: Deps,
+        offer_asset: cw_asset::Asset,
+        ask_asset_info: AssetInfo,
+        minimum_out_amount: cosmwasm_std::Uint128,
+        sender: Option<String>,
+    ) -> cosmwasm_std::StdResult<cosmwasm_std::Uint128> {
+        self.as_trait().simulate_swap(deps, offer_asset, ask_asset_info, minimum_out_amount, sender)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,10 @@
-mod error;
-mod implementations;
-mod pool;
-mod staking;
+pub mod error;
+pub mod implementations;
+pub mod traits;
+mod utils;
+
 pub use error::*;
 pub use implementations::*;
-pub use pool::*;
-pub use staking::*;
-mod utils;
 
 // #[cfg(test)]
 // pub mod tests;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -92,7 +92,7 @@ pub trait Pool {
 impl dyn Pool {
     pub fn get_pool_for_lp_token(
         _deps: Deps,
-        lp_token: AssetInfo,
+        lp_token: &AssetInfo,
     ) -> Result<Box<dyn Pool>, CwDexError> {
         match lp_token {
             cw_asset::AssetInfoBase::Native(lp_token_denom) => {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,7 +1,9 @@
 use cosmwasm_std::{Addr, Decimal, Response, StdResult};
 use cosmwasm_std::{Deps, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetList};
+use std::str::FromStr;
 
+use crate::osmosis::OsmosisPool;
 use crate::CwDexError;
 
 /// Trait to represent an AMM pool.
@@ -85,4 +87,30 @@ pub trait Pool {
         //Osmosis to fix this, or perhaps copy their math and perform the calculation here...
         sender: Option<String>,
     ) -> StdResult<Uint128>;
+}
+
+impl dyn Pool {
+    pub fn get_pool_for_lp_token(
+        _deps: Deps,
+        lp_token: AssetInfo,
+    ) -> Result<Box<dyn Pool>, CwDexError> {
+        match lp_token {
+            cw_asset::AssetInfoBase::Native(lp_token_denom) => {
+                //The only Pool implementation that uses native denoms right now is Osmosis
+                if !lp_token_denom.starts_with("gamm/pool/") {
+                    return Err(CwDexError::NotLpToken {});
+                }
+
+                let pool_id_str =
+                    lp_token_denom.strip_prefix("gamm/pool/").ok_or(CwDexError::NotLpToken {})?;
+
+                let pool_id = u64::from_str(pool_id_str).map_err(|_| CwDexError::NotLpToken {})?;
+
+                Ok(Box::new(OsmosisPool {
+                    pool_id,
+                }))
+            }
+            _ => Err(CwDexError::NotLpToken {}), //TODO: Support Astroport, Junoswap, etc.
+        }
+    }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,0 +1,5 @@
+pub mod pool;
+pub mod staking;
+
+pub use pool::*;
+pub use staking::*;

--- a/src/traits/pool.rs
+++ b/src/traits/pool.rs
@@ -1,10 +1,8 @@
 use cosmwasm_std::{Addr, Decimal, Response, StdResult};
 use cosmwasm_std::{Deps, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetList};
-use std::str::FromStr;
 
-use crate::osmosis::OsmosisPool;
-use crate::CwDexError;
+use crate::error::CwDexError;
 
 /// Trait to represent an AMM pool.
 pub trait Pool {
@@ -87,30 +85,4 @@ pub trait Pool {
         //Osmosis to fix this, or perhaps copy their math and perform the calculation here...
         sender: Option<String>,
     ) -> StdResult<Uint128>;
-}
-
-impl dyn Pool {
-    pub fn get_pool_for_lp_token(
-        _deps: Deps,
-        lp_token: &AssetInfo,
-    ) -> Result<Box<dyn Pool>, CwDexError> {
-        match lp_token {
-            cw_asset::AssetInfoBase::Native(lp_token_denom) => {
-                //The only Pool implementation that uses native denoms right now is Osmosis
-                if !lp_token_denom.starts_with("gamm/pool/") {
-                    return Err(CwDexError::NotLpToken {});
-                }
-
-                let pool_id_str =
-                    lp_token_denom.strip_prefix("gamm/pool/").ok_or(CwDexError::NotLpToken {})?;
-
-                let pool_id = u64::from_str(pool_id_str).map_err(|_| CwDexError::NotLpToken {})?;
-
-                Ok(Box::new(OsmosisPool {
-                    pool_id,
-                }))
-            }
-            _ => Err(CwDexError::NotLpToken {}), //TODO: Support Astroport, Junoswap, etc.
-        }
-    }
 }

--- a/src/traits/staking.rs
+++ b/src/traits/staking.rs
@@ -3,7 +3,7 @@ use cw_asset::{Asset, AssetList};
 use cw_utils::Duration as CwDuration;
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::CwDexError;
+use crate::error::CwDexError;
 
 /// Trait to abstract interaction with a staking contract or module with an optional lockup time.
 pub trait Staking: Clone + Serialize + DeserializeOwned {


### PR DESCRIPTION
Adds a Pool enum with a fn `get_pool_for_lp_token` that returns the Pool for a specific LP token. Also moves the traits to a trait folder. I'm not sure if this is the best way to do it, as now in consumers we must do:
```rust
use cw_dex::Pool;
use cw_dex::traits::Pool as PoolTrait;
```
since we must also import the trait to use the trait methods on the enum. Perhaps we should rename the enum and/or trait to not have the same name, but what would be suitable names for them?