### PR TITLE
feat: validate pair_type and get lp_addr from query in new()

### DIFF
--- a/src/implementations/astroport/stableswap.rs
+++ b/src/implementations/astroport/stableswap.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use astroport_core::factory::PairType;
 use astroport_core::querier::{query_supply, query_token_precision};
 use astroport_core::U256;
 use cosmwasm_schema::cw_serde;
@@ -26,11 +27,8 @@ const ITERATIONS: u8 = 32;
 pub struct AstroportStableSwapPool(AstroportBasePool);
 
 impl AstroportStableSwapPool {
-    pub fn new(pair_addr: Addr, lp_token_addr: Addr) -> Self {
-        Self(AstroportBasePool {
-            pair_addr,
-            lp_token_addr,
-        })
+    pub fn new(deps: Deps, pair_addr: Addr) -> StdResult<Self> {
+        AstroportBasePool::new(deps, pair_addr, PairType::Stable {}).map(Self)
     }
 }
 

--- a/src/implementations/astroport/xyk.rs
+++ b/src/implementations/astroport/xyk.rs
@@ -1,3 +1,4 @@
+use astroport_core::factory::PairType;
 use astroport_core::U256;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Decimal, Env, Response, StdError, StdResult};
@@ -17,11 +18,8 @@ use super::helpers::AstroAssetList;
 pub struct AstroportXykPool(AstroportBasePool);
 
 impl AstroportXykPool {
-    pub fn new(pair_addr: Addr, lp_token_addr: Addr) -> Self {
-        Self(AstroportBasePool {
-            pair_addr,
-            lp_token_addr,
-        })
+    pub fn new(deps: Deps, pair_addr: Addr) -> StdResult<Self> {
+        AstroportBasePool::new(deps, pair_addr, PairType::Xyk {}).map(Self)
     }
 }
 


### PR DESCRIPTION
Validates the pair_type and queries the pair for the LP address for `AstroportXykPool` and `AstroportStableSwapPool`

closes #43 
closes #42 