### PR TITLE
[WIP] SlippageControl enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 [[package]]
 name = "apollo-utils"
 version = "0.1.0"
-source = "git+https://github.com/apollodao/apollo-utils.git#b9caacbb112f92eaf486694759d5cf7de8af172d"
+source = "git+https://github.com/apollodao/apollo-utils.git#f042bb9b9bce31dc365e80db82d2ab6ad4356ff7"
 dependencies = [
  "cosmwasm-std",
  "cw-asset",
@@ -104,9 +104,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -245,15 +245,15 @@ dependencies = [
 
 [[package]]
 name = "cw-asset"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e955303c96778b58ad52bbbabbe10b170ae1c8df2fec08ce7d7eedf2c22701"
+version = "0.3.0"
+source = "git+https://github.com/apollodao/cw-asset.git#7c202162dca9148c65cb784f286f1da69f9bd354"
 dependencies = [
- "cosmwasm-schema",
+ "astroport",
  "cosmwasm-std",
  "cw-storage-plus 0.16.0",
- "cw1155",
  "cw20 0.16.0",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "cw-paginate"
 version = "0.2.0"
-source = "git+https://github.com/DA0-DA0/dao-contracts#6b77887ac77e43905d653c173c9b98670b5686e6"
+source = "git+https://github.com/DA0-DA0/dao-contracts#0029c06ad7facbc4b3674cd48b7fb151066d31a5"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -393,19 +393,6 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "cw1155"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be0ebb4d95abc0e3f8ea00fbcf10afec5416b0aa1122c703de69850296897c5"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils 0.16.0",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -519,7 +506,7 @@ dependencies = [
 [[package]]
 name = "cw20-stake"
 version = "0.2.6"
-source = "git+https://github.com/DA0-DA0/dao-contracts#6b77887ac77e43905d653c173c9b98670b5686e6"
+source = "git+https://github.com/DA0-DA0/dao-contracts#0029c06ad7facbc4b3674cd48b7fb151066d31a5"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1085,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "stake-cw20-external-rewards"
 version = "0.2.6"
-source = "git+https://github.com/DA0-DA0/dao-contracts#6b77887ac77e43905d653c173c9b98670b5686e6"
+source = "git+https://github.com/DA0-DA0/dao-contracts#0029c06ad7facbc4b3674cd48b7fb151066d31a5"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ osmosis-std = { git = "https://github.com/osmosis-labs/osmosis-rust", rev = "3ea
 cosmwasm-schema = "1.1.0"
 cosmwasm-std = {version = "1.1.0", features = ["stargate"]}
 cosmwasm-storage = "1.1.0"
-cw-asset = "2.3.0"
+cw-asset = { git="https://github.com/apollodao/cw-asset.git" }
 cw-storage-plus = "0.16"
 cw-utils = "0.16"
 cw20 = "0.16"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::num::TryFromIntError;
 
-use cosmwasm_std::{DivideByZeroError, OverflowError, StdError};
+use cosmwasm_std::{Decimal, DivideByZeroError, OverflowError, StdError, Uint128};
 use cw_asset::Asset;
 use thiserror::Error;
 
@@ -43,6 +43,17 @@ pub enum CwDexError {
     #[error("It is not possible to provide liquidity with one token for an empty pool")]
     InvalidProvideLPsWithSingleToken {},
 
+    #[error("Slippage control failed. Wanted minimum {wanted} but got {got}")]
+    SlippageControlMinOutFailed {
+        wanted: Uint128,
+        got: Uint128,
+    },
+
+    #[error("Slippage control failed because price moved too much.")]
+    SlippageControlPriceFailed {
+        old_price: Decimal,
+        new_price: Decimal,
+    },
 
     #[error("Asset is not an LP token")]
     NotLpToken {},

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
 use std::num::TryFromIntError;
 
-use cosmwasm_std::{Decimal, DivideByZeroError, OverflowError, StdError, Uint128};
+use cosmwasm_std::{DivideByZeroError, OverflowError, StdError, Uint128};
 use cw_asset::Asset;
 use thiserror::Error;
+
+use crate::slippage_control::Price;
 
 /// ## Description
 /// This enum describes router-test contract errors!
@@ -49,10 +51,10 @@ pub enum CwDexError {
         got: Uint128,
     },
 
-    #[error("Slippage control failed because price moved too much.")]
+    #[error("Slippage control failed because price moved too much. Old price: {old_price}, new price: {new_price}")]
     SlippageControlPriceFailed {
-        old_price: Decimal,
-        new_price: Decimal,
+        old_price: Price,
+        new_price: Price,
     },
 
     #[error("Asset is not an LP token")]
@@ -60,6 +62,18 @@ pub enum CwDexError {
 
     #[error("Expected no unbonding period")]
     UnstakingDurationNotSupported {},
+}
+
+impl From<&str> for CwDexError {
+    fn from(s: &str) -> Self {
+        CwDexError::Std(StdError::generic_err(s))
+    }
+}
+
+impl From<String> for CwDexError {
+    fn from(s: String) -> Self {
+        CwDexError::Std(StdError::generic_err(s))
+    }
 }
 
 impl From<CwDexError> for StdError {

--- a/src/implementations/osmosis/helpers.rs
+++ b/src/implementations/osmosis/helpers.rs
@@ -1,4 +1,8 @@
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
+
+use apollo_utils::iterators::TryIntoElementwise;
+use cosmwasm_std::{Coin, StdError, StdResult, Uint128};
+use prost::Message;
 
 pub(crate) trait ToProtobufDuration {
     fn to_protobuf_duration(&self) -> osmosis_std::shim::Duration;
@@ -10,5 +14,89 @@ impl ToProtobufDuration for Duration {
             seconds: self.as_secs() as i64,
             nanos: self.subsec_nanos() as i32,
         }
+    }
+}
+
+pub struct BalancerPoolAsset {
+    pub token: Coin,
+    pub weight: Uint128,
+}
+
+impl TryFrom<osmosis_std::types::osmosis::gamm::v1beta1::PoolAsset> for BalancerPoolAsset {
+    type Error = StdError;
+
+    fn try_from(
+        value: osmosis_std::types::osmosis::gamm::v1beta1::PoolAsset,
+    ) -> Result<Self, Self::Error> {
+        let token = value
+            .token
+            .ok_or_else(|| StdError::generic_err("BalancerPoolAsset::try_from: token is None"))?;
+        Ok(BalancerPoolAsset {
+            token: Coin {
+                denom: token.denom,
+                amount: Uint128::from_str(&token.amount)?,
+            },
+            weight: Uint128::from_str(&value.weight)?,
+        })
+    }
+}
+
+pub struct BalancerPoolAssets(Vec<BalancerPoolAsset>);
+
+impl From<Vec<BalancerPoolAsset>> for BalancerPoolAssets {
+    fn from(value: Vec<BalancerPoolAsset>) -> Self {
+        BalancerPoolAssets(value)
+    }
+}
+
+impl TryFrom<Vec<osmosis_std::types::osmosis::gamm::v1beta1::PoolAsset>> for BalancerPoolAssets {
+    type Error = StdError;
+
+    fn try_from(
+        value: Vec<osmosis_std::types::osmosis::gamm::v1beta1::PoolAsset>,
+    ) -> Result<Self, Self::Error> {
+        let pool_assets: Vec<BalancerPoolAsset> = value.try_into_elementwise()?;
+        Ok(Self(pool_assets))
+    }
+}
+
+impl BalancerPoolAssets {
+    pub fn get_pool_weight(&self, denom: &str) -> StdResult<Uint128> {
+        self.0
+            .iter()
+            .find(|pool_asset| pool_asset.token.denom == denom)
+            .map(|pool_asset| pool_asset.weight)
+            .ok_or_else(|| {
+                StdError::generic_err("BalancerPoolAssets::get_pool_weight: pool asset not found")
+            })
+    }
+}
+
+pub enum SupportedPoolType {
+    Balancer(osmosis_std::types::osmosis::gamm::v1beta1::Pool),
+    StableSwap(osmosis_std::types::osmosis::gamm::poolmodels::stableswap::v1beta1::Pool),
+}
+
+impl TryFrom<osmosis_std::shim::Any> for SupportedPoolType {
+    type Error = StdError;
+
+    fn try_from(value: osmosis_std::shim::Any) -> Result<Self, Self::Error> {
+        if let Ok(pool) =
+            osmosis_std::types::osmosis::gamm::v1beta1::Pool::decode(value.value.as_slice())
+        {
+            return Ok(SupportedPoolType::Balancer(pool));
+        }
+        if let Ok(pool) =
+            osmosis_std::types::osmosis::gamm::poolmodels::stableswap::v1beta1::Pool::decode(
+                value.value.as_slice(),
+            )
+        {
+            return Ok(SupportedPoolType::StableSwap(pool));
+        }
+
+        Err(StdError::ParseErr {
+            target_type: "Pool".to_string(),
+            msg: "Unmatched pool: must be either `Balancer` or `StableSwap`.".to_string(),
+        })
     }
 }

--- a/src/implementations/pool.rs
+++ b/src/implementations/pool.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 use crate::error::CwDexError;
 use crate::implementations::osmosis::OsmosisPool;
 use crate::junoswap::JunoswapPool;
+use crate::slippage_control::SlippageControl;
 use crate::traits::pool::Pool as PoolTrait;
-use crate::traits::SlippageControl;
 
 /// An enum with all known variants that implement the Pool trait.
 /// The ideal solution would of course instead be to use a trait object so that

--- a/src/implementations/pool.rs
+++ b/src/implementations/pool.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Decimal, Deps, Env, Response, StdResult, Uint128};
+use cosmwasm_std::{Deps, Env, Response, StdResult, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetInfoBase, AssetList};
 use std::str::FromStr;
 
@@ -7,6 +7,7 @@ use crate::error::CwDexError;
 use crate::implementations::osmosis::OsmosisPool;
 use crate::junoswap::JunoswapPool;
 use crate::traits::pool::Pool as PoolTrait;
+use crate::traits::SlippageControl;
 
 /// An enum with all known variants that implement the Pool trait.
 /// The ideal solution would of course instead be to use a trait object so that
@@ -57,9 +58,9 @@ impl PoolTrait for Pool {
         deps: Deps,
         env: &Env,
         assets: AssetList,
-        slippage_tolerance: Option<Decimal>,
+        slippage_control: SlippageControl,
     ) -> Result<Response, CwDexError> {
-        self.as_trait().provide_liquidity(deps, env, assets, slippage_tolerance)
+        self.as_trait().provide_liquidity(deps, env, assets, slippage_control)
     }
 
     fn withdraw_liquidity(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod implementations;
+pub mod slippage_control;
 pub mod traits;
 mod utils;
 

--- a/src/slippage_control.rs
+++ b/src/slippage_control.rs
@@ -1,0 +1,136 @@
+use std::fmt::Display;
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Uint128;
+use cosmwasm_std::{Decimal, StdError, StdResult};
+use cw_asset::AssetInfo;
+
+use crate::error::CwDexError;
+
+#[cw_serde]
+pub struct Price {
+    pub base_asset: AssetInfo,
+    pub quote_asset: AssetInfo,
+    pub price: Decimal,
+}
+
+impl Display for Price {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {} per {}", self.price, self.quote_asset, self.base_asset)
+    }
+}
+
+impl Price {
+    pub fn get_price(&self, base_asset: &AssetInfo, quote_asset: &AssetInfo) -> StdResult<Decimal> {
+        if base_asset == &self.base_asset && quote_asset == &self.quote_asset {
+            Ok(self.price)
+        } else if base_asset == &self.quote_asset && quote_asset == &self.base_asset {
+            Ok(Decimal::one() / self.price)
+        } else {
+            Err(StdError::generic_err("Price not for requested assets"))
+        }
+    }
+}
+
+/// Options for slippage control when providing liquidity (TODO: and swapping?)
+#[cw_serde]
+pub enum SlippageControl {
+    /// Require a minimum amount of LP tokens to be returned
+    MinOut(Uint128),
+    /// The user supplies a belief about the current price and the transaction
+    /// reverts if the resulting price is more than `slippage_tolerance` percent
+    /// different from `belief_price`.
+    BeliefPrice {
+        belief_price: Price,
+        slippage_tolerance: Decimal,
+    },
+    /// Require that the price in the pool does not move more than
+    /// `max_price_impact` from the current price before this transaction.
+    MaxPriceImpact {
+        max_price_impact: Decimal,
+    },
+}
+
+impl SlippageControl {
+    pub fn assert(
+        &self,
+        old_price: Price,
+        new_price: Price,
+        shares_returned: Uint128,
+    ) -> Result<(), CwDexError> {
+        match self {
+            SlippageControl::MinOut(min_out) => {
+                if &shares_returned < min_out {
+                    return Err(CwDexError::SlippageControlMinOutFailed {
+                        wanted: *min_out,
+                        got: shares_returned,
+                    });
+                }
+            }
+            SlippageControl::BeliefPrice {
+                belief_price,
+                slippage_tolerance,
+            } => {
+                let new_price_in_correct_quote =
+                    new_price.get_price(&belief_price.base_asset, &belief_price.quote_asset)?;
+
+                let max_price = belief_price.price * (Decimal::one() + *slippage_tolerance);
+                let min_price = belief_price.price * (Decimal::one() - *slippage_tolerance);
+                if new_price_in_correct_quote > max_price || new_price_in_correct_quote < min_price
+                {
+                    return Err(CwDexError::SlippageControlPriceFailed {
+                        old_price,
+                        new_price,
+                    });
+                }
+            }
+            SlippageControl::MaxPriceImpact {
+                max_price_impact,
+            } => {
+                let max_price = old_price.price * (Decimal::one() + *max_price_impact);
+                let min_price = old_price.price * (Decimal::one() - *max_price_impact);
+                if new_price.price > max_price || new_price.price < min_price {
+                    return Err(CwDexError::SlippageControlPriceFailed {
+                        old_price,
+                        new_price,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn get_min_out(&self) -> Option<Uint128> {
+        match self {
+            SlippageControl::MinOut(min_out) => Some(*min_out),
+            _ => None,
+        }
+    }
+
+    pub fn get_max_price_impact(&self) -> Option<Decimal> {
+        match self {
+            SlippageControl::MaxPriceImpact {
+                max_price_impact,
+            } => Some(*max_price_impact),
+            _ => None,
+        }
+    }
+
+    pub fn get_belief_price(&self) -> Option<Price> {
+        match self {
+            SlippageControl::BeliefPrice {
+                belief_price,
+                slippage_tolerance: _,
+            } => Some(belief_price.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl Default for SlippageControl {
+    fn default() -> Self {
+        SlippageControl::MaxPriceImpact {
+            max_price_impact: Decimal::percent(3),
+        }
+    }
+}

--- a/src/traits/pool.rs
+++ b/src/traits/pool.rs
@@ -4,6 +4,94 @@ use cw_asset::{Asset, AssetInfo, AssetList};
 
 use crate::error::CwDexError;
 
+/// Options for slippage control when providing liquidity (TODO: and swapping?)
+pub enum SlippageControl {
+    /// Require a minimum amount of LP tokens to be returned
+    MinOut(Uint128),
+    /// The user supplies a belief about the current price and the transaction
+    /// reverts if the resulting price is more than `slippage_tolerance` percent
+    /// different from `belief_price`.
+    BeliefPrice {
+        belief_price: Decimal,
+        slippage_tolerance: Decimal,
+    },
+    /// Require that the price in the pool does not move more than
+    /// `max_price_impact` from the current price before this transaction.
+    MaxPriceImpact {
+        max_price_impact: Decimal,
+    },
+}
+
+impl SlippageControl {
+    pub fn assert(
+        &self,
+        old_price: Decimal,
+        new_price: Decimal,
+        shares_returned: Uint128,
+    ) -> Result<(), CwDexError> {
+        match self {
+            SlippageControl::MinOut(min_out) => {
+                if &shares_returned < min_out {
+                    return Err(CwDexError::SlippageControlMinOutFailed {
+                        wanted: *min_out,
+                        got: shares_returned,
+                    });
+                }
+            }
+            SlippageControl::BeliefPrice {
+                belief_price,
+                slippage_tolerance,
+            } => {
+                let max_price = belief_price * (Decimal::one() + *slippage_tolerance);
+                let min_price = belief_price * (Decimal::one() - *slippage_tolerance);
+                if new_price > max_price || new_price < min_price {
+                    return Err(CwDexError::SlippageControlPriceFailed {
+                        old_price,
+                        new_price,
+                    });
+                }
+            }
+            SlippageControl::MaxPriceImpact {
+                max_price_impact,
+            } => {
+                let max_price = old_price * (Decimal::one() + *max_price_impact);
+                let min_price = old_price * (Decimal::one() - *max_price_impact);
+                if new_price > max_price || new_price < min_price {
+                    return Err(CwDexError::SlippageControlPriceFailed {
+                        old_price,
+                        new_price,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn get_min_out(&self) -> Option<Uint128> {
+        match self {
+            SlippageControl::MinOut(min_out) => Some(*min_out),
+            _ => None,
+        }
+    }
+
+    pub fn get_max_price_impact(&self) -> Option<Decimal> {
+        match self {
+            SlippageControl::MaxPriceImpact {
+                max_price_impact,
+            } => Some(*max_price_impact),
+            _ => None,
+        }
+    }
+}
+
+impl Default for SlippageControl {
+    fn default() -> Self {
+        SlippageControl::MaxPriceImpact {
+            max_price_impact: Decimal::percent(3),
+        }
+    }
+}
+
 /// Trait to represent an AMM pool.
 pub trait Pool {
     /// Provide liquidity to the pool.
@@ -18,7 +106,7 @@ pub trait Pool {
         deps: Deps,
         env: &Env,
         assets: AssetList,
-        slippage_tolerance: Option<Decimal>,
+        slippage_control: SlippageControl,
     ) -> Result<Response, CwDexError>;
 
     /// Withdraw liquidity from the pool.


### PR DESCRIPTION
Allows us to choose how to specify slippage control via an enum.
Todo is to implement for Osmosis. For that we will need to add yet another PR to Osmosis, so this is blocked by that.