### PR TITLE
Use `min_out` instead of `slippage_tolerance` for `provide_liquidity`.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 
 use std::num::TryFromIntError;
 
-use cosmwasm_std::{DivideByZeroError, OverflowError, StdError};
+use cosmwasm_std::{DivideByZeroError, OverflowError, StdError, Uint128};
 use cw_asset::Asset;
 use thiserror::Error;
 
@@ -66,6 +66,17 @@ pub enum CwDexError {
     /// When unstaking/unbonding is expected to be instant
     #[error("Expected no unbonding period")]
     UnstakingDurationNotSupported {},
+
+    /// The minimum amount of tokens requested was not returned from the action
+    #[error(
+        "Did not receive expected amount of tokens. Expected: {min_out}, received: {received}"
+    )]
+    MinOutNotReceived {
+        /// The minimum amount of tokens the user requested
+        min_out: Uint128,
+        /// The actual amount of tokens received
+        received: Uint128,
+    },
 }
 
 impl From<CwDexError> for StdError {

--- a/src/implementations/astroport/pool.rs
+++ b/src/implementations/astroport/pool.rs
@@ -314,11 +314,11 @@ impl Pool for AstroportPool {
         env: &Env,
         offer_asset: Asset,
         ask_asset_info: AssetInfo,
-        minimum_out_amount: Uint128,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError> {
         // Setting belief price to the minimium acceptable return and max spread to zero simplifies things
-        // Astroport will make the best possible swap that returns at least minimum_out_amount
-        let belief_price = Some(Decimal::from_ratio(offer_asset.amount, minimum_out_amount));
+        // Astroport will make the best possible swap that returns at least `min_out`.
+        let belief_price = Some(Decimal::from_ratio(offer_asset.amount, min_out));
         let swap_msg = match &offer_asset.info {
             AssetInfo::Native(_) => {
                 let asset = offer_asset.clone().into();
@@ -351,7 +351,7 @@ impl Pool for AstroportPool {
             .add_attribute("pair_addr", &self.pair_addr)
             .add_attribute("ask_asset", format!("{:?}", ask_asset_info))
             .add_attribute("offer_asset", format!("{:?}", offer_asset.info))
-            .add_attribute("minimum_out_amount", minimum_out_amount);
+            .add_attribute("minimum_out_amount", min_out);
         Ok(Response::new().add_message(swap_msg).add_event(event))
     }
 

--- a/src/implementations/junoswap/pool.rs
+++ b/src/implementations/junoswap/pool.rs
@@ -123,7 +123,7 @@ impl Pool for JunoswapPool {
         env: &Env,
         offer_asset: Asset,
         ask_asset_info: AssetInfo,
-        minimum_out_amount: Uint128,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError> {
         let pool_info = self.query_info(&deps.querier)?;
 
@@ -157,7 +157,7 @@ impl Pool for JunoswapPool {
             msg: to_binary(&ExecuteMsg::Swap {
                 input_token,
                 input_amount,
-                min_output: minimum_out_amount,
+                min_output: min_out,
                 expiration: None,
             })?,
         });
@@ -166,7 +166,7 @@ impl Pool for JunoswapPool {
             .add_attribute("type", "junoswap")
             .add_attribute("offer_asset", format!("{:?}", offer_asset))
             .add_attribute("ask_asset_info", format!("{:?}", ask_asset_info))
-            .add_attribute("minimum_out_amount", minimum_out_amount.to_string());
+            .add_attribute("minimum_out_amount", min_out.to_string());
 
         Ok(Response::new().add_messages(increase_allowances).add_message(swap).add_event(event))
     }

--- a/src/implementations/junoswap/pool.rs
+++ b/src/implementations/junoswap/pool.rs
@@ -4,8 +4,8 @@ use std::vec;
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Addr, CosmosMsg, Decimal, Deps, Env, Event, QuerierWrapper, QueryRequest, Response,
-    StdError, StdResult, Uint128, WasmMsg, WasmQuery,
+    to_binary, Addr, CosmosMsg, Deps, Env, Event, QuerierWrapper, QueryRequest, Response, StdError,
+    StdResult, Uint128, WasmMsg, WasmQuery,
 };
 use cw_asset::{Asset, AssetInfo, AssetList};
 use wasmswap::msg::{
@@ -45,7 +45,7 @@ impl Pool for JunoswapPool {
         deps: Deps,
         env: &Env,
         assets: AssetList,
-        slippage_tolerance: Option<Decimal>,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError> {
         let pool_info = self.query_info(&deps.querier)?;
 
@@ -53,11 +53,14 @@ impl Pool for JunoswapPool {
         let provide_liquidity_info =
             juno_simulate_provide_liquidity(&assets.try_into()?, pool_info)?;
 
-        // TODO: Is this the behavior of slippage_tolerance that we want? Right now
-        // It's a bit unclear what slippage_tolerance is supposed to do. We must
-        // define it more clearly in the trait doc comments.
-        let min_liquidity = provide_liquidity_info.lp_token_expected_amount
-            * Decimal::one().checked_sub(slippage_tolerance.unwrap_or_else(Decimal::one))?;
+        // Check if minimum LPs is met
+        let lp_out = provide_liquidity_info.lp_token_expected_amount;
+        if min_out < lp_out {
+            return Err(CwDexError::MinOutNotReceived {
+                min_out,
+                received: lp_out,
+            });
+        }
 
         // Increase allowance for cw20 tokens and add native tokens to the funds vec.
         let assets_to_use = vec![
@@ -76,7 +79,7 @@ impl Pool for JunoswapPool {
             funds,
             msg: to_binary(&ExecuteMsg::AddLiquidity {
                 token1_amount: provide_liquidity_info.token1_to_use.amount,
-                min_liquidity,
+                min_liquidity: min_out,
                 max_token2: provide_liquidity_info.token2_to_use.amount,
                 expiration: None,
             })?,

--- a/src/implementations/junoswap/staking.rs
+++ b/src/implementations/junoswap/staking.rs
@@ -109,8 +109,8 @@ impl Rewards for JunoswapStaking {
 
     fn query_pending_rewards(
         &self,
-        querier: &QuerierWrapper,
-        user: &Addr,
+        _querier: &QuerierWrapper,
+        _user: &Addr,
     ) -> Result<AssetList, CwDexError> {
         todo!("Implement JunoswapStaking::query_pending_rewards")
         // let hooks = querier

--- a/src/implementations/osmosis/pool.rs
+++ b/src/implementations/osmosis/pool.rs
@@ -116,7 +116,7 @@ impl Pool for OsmosisPool {
         env: &Env,
         offer_asset: Asset,
         ask_asset_info: AssetInfo,
-        minimum_out_amount: Uint128,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError> {
         let offer = assert_native_coin(&offer_asset)?;
         let ask_denom = assert_native_asset_info(&ask_asset_info)?;
@@ -128,14 +128,14 @@ impl Pool for OsmosisPool {
                 token_out_denom: ask_denom.clone(),
             }],
             token_in: Some(offer.clone().into()),
-            token_out_min_amount: minimum_out_amount.to_string(),
+            token_out_min_amount: min_out.to_string(),
         };
 
         let event = Event::new("apollo/cw-dex/swap")
             .add_attribute("pool_id", self.pool_id.to_string())
             .add_attribute("offer", offer.to_string())
             .add_attribute("ask", ask_denom)
-            .add_attribute("token_out_min_amount", minimum_out_amount);
+            .add_attribute("token_out_min_amount", min_out);
 
         Ok(Response::new().add_message(swap_msg).add_event(event))
     }

--- a/src/implementations/osmosis/pool.rs
+++ b/src/implementations/osmosis/pool.rs
@@ -11,9 +11,7 @@ use osmosis_std::types::osmosis::gamm::v1beta1::{
 };
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{
-    Coin, CosmosMsg, Decimal, Deps, Env, Event, Response, StdError, StdResult, Uint128,
-};
+use cosmwasm_std::{Coin, CosmosMsg, Deps, Env, Event, Response, StdError, StdResult, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetList};
 
 use crate::traits::Pool;
@@ -45,13 +43,10 @@ impl Pool for OsmosisPool {
         deps: Deps,
         env: &Env,
         mut assets: AssetList,
-        slippage_tolerance: Option<Decimal>,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError> {
         // Remove all zero amount Coins, merge duplicates and assert that all assets are native.
         let assets = assert_only_native_coins(merge_assets(assets.purge().deref())?)?;
-
-        // Unwrap slppage tolerance or set to 0% if not provided.
-        let slippage_tolerance = Decimal::one() - slippage_tolerance.unwrap_or_else(Decimal::one);
 
         // TODO: Provide liquidity double sided.
         // For now we only provide liquidity single sided since the ratio of the underlying tokens
@@ -62,25 +57,31 @@ impl Pool for OsmosisPool {
             .map(|coin| {
                 // Query expected amount of lp shares with stargate query
                 let expected_shares =
-                    self.simulate_provide_liquidity(deps, env, vec![coin.clone()].into())?;
-
-                // Calculate minimum shares
-                let shares_out_min = slippage_tolerance * expected_shares.amount;
+                    self.simulate_provide_liquidity(deps, env, vec![coin.clone()].into())?.amount;
 
                 Ok((
                     MsgJoinSwapExternAmountIn {
                         sender: env.contract.address.to_string(),
                         pool_id: self.pool_id,
                         token_in: Some(coin.into()),
-                        share_out_min_amount: shares_out_min.to_string(),
+                        share_out_min_amount: expected_shares.to_string(),
                     }
                     .into(),
-                    shares_out_min,
+                    expected_shares,
                 ))
             })
             .collect::<StdResult<Vec<_>>>()?
             .into_iter()
             .unzip();
+
+        // Assert slippage tolerance
+        let expected_lps = shares_out.iter().sum::<Uint128>();
+        if min_out < expected_lps {
+            return Err(CwDexError::MinOutNotReceived {
+                min_out,
+                received: expected_lps,
+            });
+        }
 
         let event = Event::new("apollo/cw-dex/provide_liquidity")
             .add_attribute("pool_id", self.pool_id.to_string())

--- a/src/implementations/pool.rs
+++ b/src/implementations/pool.rs
@@ -87,9 +87,9 @@ impl PoolTrait for Pool {
         env: &Env,
         offer_asset: Asset,
         ask_asset_info: AssetInfo,
-        minimum_out_amount: Uint128,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError> {
-        self.as_trait().swap(deps, env, offer_asset, ask_asset_info, minimum_out_amount)
+        self.as_trait().swap(deps, env, offer_asset, ask_asset_info, min_out)
     }
 
     fn get_pool_liquidity(&self, deps: Deps) -> Result<AssetList, CwDexError> {

--- a/src/implementations/pool.rs
+++ b/src/implementations/pool.rs
@@ -2,7 +2,7 @@
 //! For use in serialization.
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Decimal, Deps, Env, Response, StdResult, Uint128};
+use cosmwasm_std::{Deps, Env, Response, StdResult, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetInfoBase, AssetList};
 use std::str::FromStr;
 
@@ -67,9 +67,9 @@ impl PoolTrait for Pool {
         deps: Deps,
         env: &Env,
         assets: AssetList,
-        slippage_tolerance: Option<Decimal>,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError> {
-        self.as_trait().provide_liquidity(deps, env, assets, slippage_tolerance)
+        self.as_trait().provide_liquidity(deps, env, assets, min_out)
     }
 
     fn withdraw_liquidity(

--- a/src/traits/pool.rs
+++ b/src/traits/pool.rs
@@ -42,8 +42,9 @@ pub trait Pool {
     /// Swap assets in the pool.
     ///
     /// Arguments:
-    /// - `offer`: the offer asset
-    /// - `ask`: the ask asset
+    /// - `offer_asset`: The asset we want to swap.
+    /// - `ask_asset`: The asset we want to receive from the swap.
+    /// - `min_out`: The minimum amount of `ask_asset` to receive.
     ///
     /// Returns a Response containing the messages to swap assets in the pool.
     fn swap(

--- a/src/traits/pool.rs
+++ b/src/traits/pool.rs
@@ -1,7 +1,7 @@
 //! Contains the `Pool` trait which describes an interface to an AMM pool.
 
-use cosmwasm_std::{Decimal, Env, Response, StdResult};
 use cosmwasm_std::{Deps, Uint128};
+use cosmwasm_std::{Env, Response, StdResult};
 use cw_asset::{Asset, AssetInfo, AssetList};
 
 use crate::error::CwDexError;
@@ -14,13 +14,15 @@ pub trait Pool {
     /// `assets` must only contain the assets in the pool, but the ratio of
     /// amounts does not need to be the same as the pool's ratio.
     ///
-    /// TODO: Document how slippage_tolerance works. When will it fail?
+    /// Arguments:
+    /// - `assets`: the assets to provide liquidity with
+    /// - `min_out`: the minimum amount of LP tokens to receive
     fn provide_liquidity(
         &self,
         deps: Deps,
         env: &Env,
         assets: AssetList,
-        slippage_tolerance: Option<Decimal>,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError>;
 
     /// Withdraw liquidity from the pool.

--- a/src/traits/pool.rs
+++ b/src/traits/pool.rs
@@ -52,7 +52,7 @@ pub trait Pool {
         env: &Env,
         offer_asset: Asset,
         ask_asset_info: AssetInfo,
-        minimum_out_amount: Uint128,
+        min_out: Uint128,
     ) -> Result<Response, CwDexError>;
 
     // === Query functions ===

--- a/src/traits/pool.rs
+++ b/src/traits/pool.rs
@@ -14,6 +14,11 @@ pub trait Pool {
     /// `assets` must only contain the assets in the pool, but the ratio of
     /// amounts does not need to be the same as the pool's ratio.
     ///
+    /// All implementations of this trait should try to use as much of the provided
+    /// assets as possible, but it may leave some in the contracts balance if they
+    /// are not exactly in the same ratio as the pool. All implementations should
+    /// return an error if the returned amount of LP tokens is less than `min_out`.
+    ///
     /// Arguments:
     /// - `assets`: the assets to provide liquidity with
     /// - `min_out`: the minimum amount of LP tokens to receive


### PR DESCRIPTION
The other options were unfortunately infeasible for now. Mainly we need to add more queries on Osmosis to support price-based slippage tolerance.