### PR TITLE
Various fixes

### DIFF
--- a/src/implementations/astroport/pool.rs
+++ b/src/implementations/astroport/pool.rs
@@ -1,5 +1,7 @@
 //! Pool trait implementation for Astroport
 
+use std::str::FromStr;
+
 use astroport_core::asset::PairInfo;
 use astroport_core::factory::PairType;
 use astroport_core::querier::{query_supply, query_token_precision};
@@ -15,7 +17,7 @@ use cw_asset::{Asset, AssetInfo, AssetInfoBase, AssetList};
 use astroport_core::asset::AssetInfo as AstroAssetInfo;
 use astroport_core::pair::{
     Cw20HookMsg, ExecuteMsg as PairExecMsg, PoolResponse, QueryMsg, QueryMsg as PairQueryMsg,
-    SimulationResponse,
+    SimulationResponse, MAX_ALLOWED_SLIPPAGE,
 };
 
 use crate::traits::Pool;
@@ -269,7 +271,7 @@ impl Pool for AstroportPool {
 
         let msg = PairExecMsg::ProvideLiquidity {
             assets: assets.to_owned().try_into()?,
-            slippage_tolerance: None,
+            slippage_tolerance: Some(Decimal::from_str(MAX_ALLOWED_SLIPPAGE)?),
             auto_stake: Some(false),
             receiver: None,
         };

--- a/src/implementations/osmosis/pool.rs
+++ b/src/implementations/osmosis/pool.rs
@@ -42,7 +42,7 @@ impl Pool for OsmosisPool {
         &self,
         deps: Deps,
         env: &Env,
-        mut assets: AssetList,
+        assets: AssetList,
         min_out: Uint128,
     ) -> Result<Response, CwDexError> {
         let mut assets = assets;

--- a/src/implementations/pool.rs
+++ b/src/implementations/pool.rs
@@ -6,6 +6,7 @@ use cosmwasm_std::{Deps, Env, Response, StdResult, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetInfoBase, AssetList};
 use std::str::FromStr;
 
+use crate::astroport::AstroportPool;
 use crate::error::CwDexError;
 use crate::implementations::osmosis::OsmosisPool;
 use crate::junoswap::JunoswapPool;
@@ -22,6 +23,8 @@ pub enum Pool {
     Osmosis(OsmosisPool),
     /// Contains an Junoswap pool implementation
     Junoswap(JunoswapPool),
+    /// Contains an Astroport pool implementation
+    Astroport(AstroportPool),
 }
 
 impl Pool {
@@ -30,6 +33,7 @@ impl Pool {
         match self {
             Pool::Osmosis(x) => Box::new(*x),
             Pool::Junoswap(x) => Box::new(x.clone()),
+            Pool::Astroport(x) => Box::new(x.clone()),
         }
     }
 

--- a/src/traits/pool.rs
+++ b/src/traits/pool.rs
@@ -1,3 +1,5 @@
+//! Contains the `Pool` trait for abstracting the behavior of a dex pool.
+
 use cosmwasm_std::{Deps, Env, Response, StdResult, Uint128};
 use cw_asset::{Asset, AssetInfo, AssetList};
 


### PR DESCRIPTION
- Add AstroportPool variant to Pool enum
- Fix compilation warnings
- Rename `get_pool_liquidity_impl` to `query_pool_info` and make it public for use in `astroport-liquidity-helper`.
- Use max allowed slippage tolerance in astroport when providing liquidity to XYK pool